### PR TITLE
Fix: #6 - Show correct time when restarting a timer

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -53,6 +53,7 @@ const App = () => {
 			timer_started_at: latest.timer_started_at,
 			hours: latest.hours,
 			notes: latest.notes,
+			hours_without_timer: latest.hours_without_timer,
 		});
 	};
 

--- a/src/components/HarvestTask.js
+++ b/src/components/HarvestTask.js
@@ -73,7 +73,7 @@ const HarvestTask = ({ task, runningTask, onTaskClick, projectData }) => {
 				{runningTask &&
 					runningTask.task_id === task.task.id &&
 					runningTask.project_id === projectData.project.id && (
-						<Timer start={runningTask.timer_started_at} />
+						<Timer task={runningTask} />
 					)}
 			</li>
 		</>

--- a/src/components/JiraColumn.js
+++ b/src/components/JiraColumn.js
@@ -76,8 +76,6 @@ const JiraColumn = ({
 			return;
 		}
 
-		console.log('Moving ticket', ticket.key, 'to', column.name);
-
 		const response = await postMoveTicket(ticket.id, transition.id, board.info);
 
 		if (!response.ok) {

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -3,13 +3,15 @@ import { useState, useEffect } from 'react';
 /**
  * Timer component
  *
- * @param {object} props       - The props object
- * @param {string} props.start - The start time
+ * @param {object} props      - The props object
+ * @param {object} props.task - The task object
  *
  * @returns {JSX.Element} - The Timer component
  */
-const Timer = ({ start }) => {
+const Timer = ({ task }) => {
 	const [elapsedTime, setElapsedTime] = useState(0);
+
+	const { timer_started_at, hours_without_timer } = task;
 
 	/**
 	 * Format the time
@@ -26,15 +28,19 @@ const Timer = ({ start }) => {
 	};
 
 	useEffect(() => {
-		const startTime = new Date(start);
+		const startTime = new Date(timer_started_at);
 		const interval = setInterval(() => {
 			const now = new Date();
 			const elapsed = Math.floor((now - startTime) / 1000);
-			setElapsedTime(elapsed);
+			const seconds_without_timer = Math.floor(hours_without_timer * 3600);
+
+			const total = seconds_without_timer + elapsed;
+
+			setElapsedTime(total);
 		}, 1000);
 
 		return () => clearInterval(interval);
-	}, [start]);
+	}, [timer_started_at, hours_without_timer]);
 
 	return <div className="timer">{formatTime(elapsedTime)}</div>;
 };


### PR DESCRIPTION
Fixes #6 

## Description

<!-- Provide a description of what this PR adds/changes -->

This PR fixes the issue where if a timer was restarted in harvest, it would not show the correct time, and would instead show the amount of time since it was restarted.

## Change Log

<!-- This should include anything that has changed, been added/remove, and fixed within this PR. -->

- Used `hours_without_timer` to get how long the timer had ran before it was restarted
- Removed unused `console.log`

## Testing Steps

<!-- Describe how to test your changes -->

1. Start a timer
2. Stop that timer
3. set the timer to a large amount of time from the harvest site
4. Restart the timer from the harvest site
5. see that the shown time is correct

## Screenshots/Videos

<!-- Provide screenshots/screen recordings of your PR working -->

## Checklist
- [x] I have tested this change and to works as expected.
- [x] I have added/updated documentation where required.
- [x] I have run `yarn lint` to ensure code quality.
