### PR TITLE
Fix: #25 -Timer showing NAN:NAN when starting

### DIFF
--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -11,7 +11,7 @@ import { useState, useEffect } from 'react';
 const Timer = ({ task }) => {
 	const [elapsedTime, setElapsedTime] = useState(0);
 
-	const { timer_started_at, hours_without_timer } = task;
+	const { timer_started_at, hours_without_timer = 0 } = task;
 
 	/**
 	 * Format the time


### PR DESCRIPTION
Fixes #25 

## Description

<!-- Provide a description of what this PR adds/changes -->

This PR fixes an issue with the timer, where for the first few seconds after starting it would show `NAN:NAN`

## Change Log

<!-- This should include anything that has changed, been added/remove, and fixed within this PR. -->

- Add fallback for the `seconds_without_timer` attribute

## Testing Steps

<!-- Describe how to test your changes -->

1. Start a timer
2. See the timer does not show `NAN:NAN`
3. Repeat 3 times

## Screenshots/Videos

<!-- Provide screenshots/screen recordings of your PR working -->

## Checklist
- [x] I have tested this change and to works as expected.
- [x] I have added/updated documentation where required.
- [x] I have run `yarn lint` to ensure code quality.
