### PR TITLE
Fix: #24 - Unable to stop timers with notes

### DIFF
--- a/src/components/HarvestTask.js
+++ b/src/components/HarvestTask.js
@@ -42,7 +42,6 @@ const HarvestTask = ({ task, runningTask, onTaskClick, projectData }) => {
 						id={`note-${task.task.id}-${projectData.project.id}`}
 						name={`note-${task.task.id}-${projectData.project.id}`}
 						rows="4"
-						// cols="50"
 						placeholder="Enter a note..."
 					/>
 				</div>

--- a/src/views/HarvestProject.js
+++ b/src/views/HarvestProject.js
@@ -88,13 +88,25 @@ const HarvestProject = ({
 	 * @returns {void}
 	 */
 	const onTaskClick = async (task, note = null, jiraTask = false) => {
+		// If the same task is already running and is not a Jira task, stop the timer
 		if (
 			runningTask &&
 			parseInt(runningTask.task_id) === parseInt(task.task.id) &&
 			runningTask.project_id === projectData.project.id &&
-			note === runningTask.notes &&
+			note === null &&
 			!jiraTask
 		) {
+			await stopTimer(runningTask.time_entry_id);
+			setRunningTask(null);
+			return;
+		} else if (
+			runningTask &&
+			parseInt(runningTask.task_id) === parseInt(task.task.id) &&
+			runningTask.project_id === projectData.project.id &&
+			note === runningTask.notes &&
+			jiraTask
+		) {
+			console.log('stopping timer');
 			await stopTimer(runningTask.time_entry_id);
 			setRunningTask(null);
 			return;


### PR DESCRIPTION
Fixes #24 

## Description

<!-- Provide a description of what this PR adds/changes -->

This PR fixes the issue where if a timer with a note was stopped, it would start a new timer instead of stopping it.

## Change Log

<!-- This should include anything that has changed, been added/remove, and fixed within this PR. -->

- Adds an extra check to see if the click was from a Jira task
- Changes the check to see if the note is set to null

## Testing Steps

<!-- Describe how to test your changes -->

1. Start a timer with a note
2. Click the timer again to stop the timer
3. See the timer has stopped

## Screenshots/Videos

<!-- Provide screenshots/screen recordings of your PR working -->

## Checklist
- [x] I have tested this change and to works as expected.
- [x] I have added/updated documentation where required.
- [x] I have run `yarn lint` to ensure code quality.
