### PR TITLE
Feature: #28 - Make the Column Headings sticky

### DIFF
--- a/src/components/JiraColumn.js
+++ b/src/components/JiraColumn.js
@@ -113,7 +113,9 @@ const JiraColumn = ({
 			className={`jira-column ${isOver ? 'is-over' : ''}`}
 			ref={drop}
 		>
-			<h4>{column.name}</h4>
+			<div className="jira-column-header">
+				<h4>{column.name}</h4>
+			</div>
 			<ul className="jira-tickets">
 				{tickets
 					.filter(

--- a/src/styles/components/_JiraBoard.scss
+++ b/src/styles/components/_JiraBoard.scss
@@ -12,32 +12,6 @@
   border-top-left-radius: 0;
 }
 
-/**
- * Jira Board Columns
- */
-.jira-board .jira-columns {
-  display: grid;
-  gap: 0.5rem;
-  list-style: none;
-  overflow: scroll;
-  padding: 0;
-
-  > li.jira-column {
-    background-color: light-dark(#eaeaea, #666);
-    border-radius: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-height: 80vh;
-    overflow: scroll;
-    padding: 1rem;
-  }
-
-  > li.jira-column h4 {
-    margin: 0;
-  }
-}
-
 
 /**
  * Board Header
@@ -77,4 +51,3 @@
     rotate: 45deg;
   }
 }
-

--- a/src/styles/components/_JiraColumn.scss
+++ b/src/styles/components/_JiraColumn.scss
@@ -1,0 +1,37 @@
+/**
+ * Jira Board Columns
+ */
+.jira-board .jira-columns {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  overflow: scroll;
+  padding: 0;
+
+  > li.jira-column {
+    background-color: light-dark(#eaeaea, #666);
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 80vh;
+    padding: 1rem;
+
+    > ul {
+    overflow: scroll;
+    }
+  }
+
+  > li.jira-column .jira-column-header {
+    height: 1.5rem;
+
+    h4 {
+      margin: 0;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      font-size: 1rem;
+      line-height: 1.5rem;
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -18,6 +18,7 @@
 @import './components/PillBox';
 @import './components/TokenInput';
 @import './components/JiraBoard';
+@import './components/JiraColumn';
 @import './components/JiraTicket';
 @import './components/HarvestTask';
 @import './components/Modal';


### PR DESCRIPTION
Closes #28 

## Description

<!-- Provide a description of what this PR adds/changes -->
This PR moves the `overflow: scroll` from the whole column to just the tickets list, this makes the column heading always appear. I also added styles to the heading which gives uniformity to the columns.

## Change Log

<!-- This should include anything that has changed, been added/remove, and fixed within this PR. -->

- Created `_JiraColumn.scss`
- Moved the scroll to the ticket list
- Added height, and `text-overflow: ellipsis` to the headings

## Testing Steps

<!-- Describe how to test your changes -->

1. View a Jira board
2. See the headings which span multiple lines are now cut off with an ellipsis
3. See the headings still show when the ticket list is scrolled

## Screenshots/Videos

<!-- Provide screenshots/screen recordings of your PR working -->

## Checklist
- [x] I have tested this change and to works as expected.
- [x] I have added/updated documentation where required.
- [x] I have run `yarn lint` to ensure code quality.
